### PR TITLE
修复 tvOS 编译问题和潜在的crash问题

### DIFF
--- a/Sources/DanmakuKit/Classes/Core/DanmakuAsyncLayer.swift
+++ b/Sources/DanmakuKit/Classes/Core/DanmakuAsyncLayer.swift
@@ -77,7 +77,7 @@ public class DanmakuAsyncLayer: CALayer {
     }
     
     private func display(isAsync: Bool) {
-        guard displaying != nil else {
+        guard displaying != nil, bounds.size.width > 0, bounds.size.height > 0 else {
             willDisplay?(self)
             contents = nil
             didDisplay?(self, true)

--- a/Sources/DanmakuKit/Classes/SwiftUI/DanmakuViewAdapter.swift
+++ b/Sources/DanmakuKit/Classes/SwiftUI/DanmakuViewAdapter.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@available(iOS 14.0, *)
+@available(iOS 14.0, tvOS 14.0, *)
 public struct DanmakuViewAdapter: UIViewRepresentable {
     
     public typealias UIViewType = DanmakuView


### PR DESCRIPTION
现在误传入空弹幕的size会导致crash，添加多一个条件检查